### PR TITLE
Upgraded to Spring Boot 1.2.5.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.4.RELEASE</version>
+		<version>1.2.5.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<modules>
@@ -21,7 +21,7 @@
  			<dependency>
  				<groupId>org.springframework.boot</groupId>
  				<artifactId>spring-boot-configuration-processor</artifactId>
- 				<version>1.2.4.RELEASE</version>
+ 				<version>1.2.5.RELEASE</version>
  			</dependency>
  			<dependency>
 				<groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Upgraded to Spring Boot 1.2.5.RELEASE.  We have a production issue that is dependent on Spring Framework 4.1.7, which is in Spring Boot 1.2.5.RELEASE.