### PR TITLE
Added documentation about configuring m2eclipe to use .settings.xml file

### DIFF
--- a/docs/src/main/asciidoc/building-base.adoc
+++ b/docs/src/main/asciidoc/building-base.adoc
@@ -53,6 +53,14 @@ We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working w
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
+Once the projects are imported into Eclipse you will also need to tell m2eclipse
+to use the `.settings.xml` file for the projects.  If you do not do this you may 
+see errors many different errors related to the POMs in the projects. 
+Open your Eclipse preferences, expand the Maven preferences, and select User Settings.  
+In the User Settings field click Browse and navigate to the Spring Cloud project you
+imported selecting the `.settings.xml` file in that project.  Click Apply and then OK to 
+save the preference changes.
+
 ==== Importing into eclipse without m2eclipse
 If you prefer not to use m2eclipse you can generate eclipse project metadata using the
 following command:


### PR DESCRIPTION
Ran into a couple of problems with build errors in eclipse when importing spring-cloud-netflix.  I found that configuring m2eclipse to use the .settings.xml in the project solves these issues.  Think it would be useful for others as well so we should document it.