### PR TITLE
Add 'fast' profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -839,5 +839,11 @@ limitations under the License.
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>fast</id>
+			<properties>
+				<checkstyle.skip>true</checkstyle.skip>
+			</properties>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
Allow to provide settings that circumvent certain steps (e.g. Checkstyle validation)
when they are not deemed necessary.