### PR TITLE
Add version for maven jar/javadoc/source plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@ limitations under the License.
 		<plugins>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>2.10.4</version>
 				<executions>
 					<execution>
 						<id>javadoc</id>
@@ -147,6 +147,7 @@ limitations under the License.
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -176,6 +177,7 @@ limitations under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
+					<version>2.6</version>
 					<configuration>
 						<archive>
 							<manifest>


### PR DESCRIPTION
* Use latest versions in 2.x family of plugins.
Fixes #45 