### PR TITLE
Maven Configuration Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -662,13 +662,13 @@ limitations under the License.
 										<goal>run</goal>
 									</goals>
 									<configuration>
-										<tasks>
+										<target>
 											<java classname="org.jruby.Main" failonerror="yes">
 												<arg value="${basedir}/src/main/ruby/generate_readme.sh"/>
 												<arg value="-o"/>
 												<arg value="${main.basedir}/README.adoc"/>
 											</java>
-										</tasks>
+										</target>
 									</configuration>
 								</execution>
 								<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -749,6 +749,7 @@ limitations under the License.
 						<plugin>
 							<groupId>org.codehaus.mojo</groupId>
 							<artifactId>build-helper-maven-plugin</artifactId>
+							<version>3.0.0</version>
 							<executions>
 								<execution>
 									<id>attach-zip</id>


### PR DESCRIPTION
This minor PR solves a couple issues:

- Missing `build-helper-maven-plugin` version
- Deprecated parameter from `maven-antrun-plugin` should be refactored from `tasks` to `target`.  See [docs](http://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html#tasks)

