### PR TITLE
GitHub Templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+
+# Contributing
+
+Spring Cloud is released under the non-restrictive Apache 2.0 license,
+and follows a very standard Github development process, using Github
+tracker for issues and merging pull requests into master. If you want
+to contribute even something trivial please do not hesitate, but
+follow the guidelines below.
+
+## Sign the Contributor License Agreement
+Before we accept a non-trivial patch or pull request we will need you to sign the
+https://cla.pivotal.io/sign/spring[Contributor License Agreement].
+Signing the contributor's agreement does not grant anyone commit rights to the main
+repository, but it does mean that we can accept your contributions, and you will get an
+author credit if we do.  Active contributors might be asked to join the core team, and
+given the ability to merge pull requests.
+
+## Code of Conduct
+This project adheres to the Contributor Covenant https://github.com/spring-cloud/spring-cloud-build/blob/master/docs/src/main/asciidoc/code-of-conduct.adoc[code of
+conduct]. By participating, you  are expected to uphold this code. Please report
+unacceptable behavior to spring-code-of-conduct@pivotal.io.
+
+## Code Conventions and Housekeeping
+None of these is essential for a pull request, but they will all help.  They can also be
+added after the original pull request but before a merge.
+
+* Use the Spring Framework code format conventions. If you use Eclipse
+  you can import formatter settings using the
+  `eclipse-code-formatter.xml` file from the
+  https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
+  Cloud Build] project. If using IntelliJ, you can use the
+  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  Plugin] to import the same file.
+* Make sure all new `.java` files to have a simple Javadoc class comment with at least an
+  `@author` tag identifying you, and preferably at least a paragraph on what the class is
+  for.
+* Add the ASF license header comment to all new `.java` files (copy from existing files
+  in the project)
+* Add yourself as an `@author` to the .java files that you modify substantially (more
+  than cosmetic changes).
+* Add some Javadocs and, if you change the namespace, some XSD doc elements.
+* A few unit tests would help a lot as well -- someone has to do it.
+* If no-one else is using your branch, please rebase it against the current master (or
+  other target branch in the main project).
+* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+  if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
+  message (where XXXX is the issue number).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+Thanks for raising a Spring Boot issue. What sort of issue are you raising?
+
+Question
+
+Please ask questions about how to use something, or to understand why something isn't
+working as you expect it to, on Stack Overflow using the spring-boot tag.
+
+Bug report
+
+Please provide details of the problem, including the version of Spring Boot that you
+are using. If possible, please provide a test case or sample application that reproduces
+the problem. This makes it much easier for us to diagnose the problem and to verify that
+we have fixed it.
+
+Enhancement
+
+Please start by describing the problem that you are trying to solve. There may already
+be a solution, or there may be a way to solve it that you hadn't considered.
+-->


### PR DESCRIPTION
Fixes #63.

@spencergibb @dsyer @marcingrzejszczak I think it would be a good idea to set some type of templates for users who are creating issue and contributing code.  I copied the Boot issue template, seems like a good starting point.  Not sure if we want to point everyone to SO if they just have a question, I dont mind using issues for that personally.  Anything else we want to add?

The contributions guidelines is kind of repetitive.  We already have that in the `README`, but it seem kind of silly to have a `CONTRIBUTING.md` file that just pointed them to the `README`.  Maybe we dont use `CONTRIBUTING.md` and just keep everything in the README or we take the contribution guidelines out of the `README`.  What do you think?

We would have to copy this to each project once we finalize the content.