### PR TITLE
GH-62: Fix Checkstyle plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,8 @@ limitations under the License.
 							<phase>validate</phase>
 							<inherited>true</inherited>
 							<configuration>
-								<headerLocation>spring-cloud-build-tools/src/main/resources/checkstyle-header.txt</headerLocation>
+								<configLocation>checkstyle.xml</configLocation>
+								<headerLocation>checkstyle-header.txt</headerLocation>
 								<propertyExpansion>checkstyle.build.directory=${project.build.directory}</propertyExpansion>
 								<consoleOutput>true</consoleOutput>
 								<!-- TODO: Start fixing the errors -->


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-build#62

Since Checkstyle plugin is declared in the dependency management, we
can't use a relative path to Checkstyle resources.
We can only rely on the classpath as it is present in the
`spring-cloud-build-tools` dependency, so downstream projects just rely
on the common Checkstyle configuration from the parent