### PR TITLE
Add link to Spring Cloud Build project to IntelliJ setup docs

### DIFF
--- a/docs/src/main/asciidoc/contributing.adoc
+++ b/docs/src/main/asciidoc/contributing.adoc
@@ -131,6 +131,7 @@ $ touch .springformat
 ==== Intellij IDEA
 
 In order to setup Intellij you should import our coding conventions, inspection profiles and set up the checkstyle plugin.
+The following files can be found in the https://github.com/spring-cloud/spring-cloud-build/tree/master/spring-cloud-build-tools[Spring Cloud Build] project.
 
 .spring-cloud-build-tools/
 ----


### PR DESCRIPTION
This would have helped me when setting up Checkstyle in the Spring Cloud Config project. I think a lot of IJ users will skip to this section like I did and miss the fact that these files aren’t in the local repo. Otherwise the docs are great.