### PR TITLE
Update doc-resources-version, change highlight

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<spring-cloud-build.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-build.version>
 		<docs.resources.dir>${project.build.directory}/build-docs</docs.resources.dir>
 		<refdocs.build.directory>${project.build.directory}/refdocs/</refdocs.build.directory>
-		<spring-doc-resources.version>0.1.0.RELEASE</spring-doc-resources.version>
+		<spring-doc-resources.version>0.2.0.RELEASE</spring-doc-resources.version>
 		<spring-asciidoctor-extensions.version>0.1.3.RELEASE
 		</spring-asciidoctor-extensions.version>
 		<asciidoctorj-pdf.version>1.5.0-alpha.18</asciidoctorj-pdf.version>
@@ -1138,7 +1138,7 @@
 										<doctype>book</doctype>
 										<attributes>
 											<highlightjsdir>js/highlight</highlightjsdir>
-											<highlightjs-theme>atom-one-dark-reasonable</highlightjs-theme>
+											<highlightjs-theme>github</highlightjs-theme>
 											<linkcss>true</linkcss>
 											<imagesdir>./images</imagesdir>
 											<icons>font</icons>
@@ -1172,7 +1172,7 @@
 										<doctype>book</doctype>
 										<attributes>
 											<highlightjsdir>js/highlight</highlightjsdir>
-											<highlightjs-theme>atom-one-dark-reasonable</highlightjs-theme>
+											<highlightjs-theme>github</highlightjs-theme>
 											<linkcss>true</linkcss>
 											<imagesdir>./images</imagesdir>
 											<icons>font</icons>


### PR DESCRIPTION
Update the doc-resources-version to pick up the new look and feel that
Damien Vitrac designed.

Also changed to the Github highlight, which is now the standard, for
which Damien designed.