### PR TITLE
Added both sonatype and repo.spring.io as target for our deployed artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -769,6 +769,18 @@
 		</profile>
 		<profile>
 			<id>central</id>
+			<distributionManagement>
+				<repository>
+					<id>repo.spring.io</id>
+					<name>Spring Release Repository</name>
+					<url>https://repo.spring.io/libs-release-local</url>
+				</repository>
+				<repository>
+					<id>sonatype-nexus-staging</id>
+					<name>Nexus Release Repository</name>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
That way we will automatically have theGA documentation present in docs.spring.io