### PR TITLE
Upgrade spring-doc-resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<spring-cloud-build.version>3.0.0-SNAPSHOT</spring-cloud-build.version>
 		<docs.resources.dir>${project.build.directory}/build-docs</docs.resources.dir>
 		<refdocs.build.directory>${project.build.directory}/refdocs/</refdocs.build.directory>
-		<spring-doc-resources.version>0.2.0.RELEASE</spring-doc-resources.version>
+		<spring-doc-resources.version>0.2.1.RELEASE</spring-doc-resources.version>
 		<spring-asciidoctor-extensions.version>0.2.0.RELEASE
 		</spring-asciidoctor-extensions.version>
 		<asciidoctorj-pdf.version>1.5.0-alpha.18</asciidoctorj-pdf.version>


### PR DESCRIPTION
Upgrade spring-doc-resources from version 0.2.0 to version 0.2.1
to get a bug fix (setting the width of the HTML output).