### PR TITLE
fix(bashScript): download shellcheck to support arm64 processor

### DIFF
--- a/docs/src/test/bash/build-helper.sh
+++ b/docs/src/test/bash/build-helper.sh
@@ -20,13 +20,17 @@ if [[ $# -ne 1 ]]; then
     usage
 fi
 
-SHELLCHECK_VERSION="v0.6.0"
+SHELLCHECK_VERSION="v0.7.0"
+ARCH="x86_64"
+if [ "$(uname -m)" == aarch64 ]; then
+    ARCH="aarch64"
+fi
 SHELLCHECK_BIN="${ROOT_DIR}/../target/shellcheck-${SHELLCHECK_VERSION}/shellcheck"
 
 case $1 in
     download-shellcheck)
         if [[ "${OSTYPE}" == linux* && ! -z "${SHELLCHECK_BIN}" ]]; then
-            SHELLCHECK_ARCHIVE="shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+            SHELLCHECK_ARCHIVE="shellcheck-${SHELLCHECK_VERSION}.linux.${ARCH}.tar.xz"
             if [[ -x "${ROOT_DIR}/../target/shellcheck-${SHELLCHECK_VERSION}/shellcheck" ]]; then
                 echo "shellcheck already downloaded - skipping..."
                 exit 0


### PR DESCRIPTION
build_helper.sh just downloads shellcheck for x86_64 architecture by hard coding the verison and arch of zip file. Fortunately shellcheck starts to support arm64 since version 0.7.0, as a result add checking for architecture to support arm64.

Signed-off-by: maaaace <fuheming@huawei.com>