### PR TITLE
Remove lf from NewlineAtEndOfFileCheck

### DIFF
--- a/spring-cloud-build-tools/src/main/resources/checkstyle.xml
+++ b/spring-cloud-build-tools/src/main/resources/checkstyle.xml
@@ -20,9 +20,7 @@
 		<property name="headerFile" value="${checkstyle.header.file}"/>
 		<property name="fileExtensions" value="java,groovy"/>
 	</module>
-	<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck">
-		<property name="lineSeparator" value="lf"/>
-	</module>
+	<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck"/>
 
 	<!-- TreeWalker Checks -->
 	<module name="com.puppycrawl.tools.checkstyle.TreeWalker">


### PR DESCRIPTION
Different OSs may check out files with different line separators.
So, to better support other development environments it would be great to just require any end of file, not just Linux-specific.