### PR TITLE
Escape special characters for config Asciidoc

### DIFF
--- a/docs/src/main/java/org/springframework/cloud/internal/Main.java
+++ b/docs/src/main/java/org/springframework/cloud/internal/Main.java
@@ -144,7 +144,7 @@ public class Main {
 		}
 
 		public String toString() {
-			return "|" + name + " | " + (StringUtils.hasText(defaultValue) ? ("`" + defaultValue + "`") : "") + " | " + description;
+			return "|" + name + " | " + (StringUtils.hasText(defaultValue) ? ("`+++" + defaultValue + "+++`") : "") + " | " + description;
 		}
 
 	}


### PR DESCRIPTION
Disabling parsing of special characters in Asciidoc to show valid configuration examples.

I'm not sure about the whole .adoc-generation process. I hope, changing this file is sufficient.
The result should look like, I tried here before: [#2183](https://github.com/spring-cloud/spring-cloud-sleuth/pull/2183)