### PR TITLE
Fix Syntax Highlighting for Documentations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1208,6 +1208,7 @@
 									<raw-docs-url>${github-raw}@</raw-docs-url>
 									<project-version>${project.version}@</project-version>
 									<project-name>${docs.main}@</project-name>
+									<source-highlighter>highlight.js</source-highlighter>
 								</attributes>
 								<!-- end::attributes[] -->
 								<requires>
@@ -1240,7 +1241,7 @@
 											<highlightjs-theme>github</highlightjs-theme>
 											<imagesdir>./images</imagesdir>
 											<attribute-missing>warn</attribute-missing>
-											<sourceHighlighter>highlight.js</sourceHighlighter>
+											<source-highlighter>highlight.js</source-highlighter>
 										</attributes>
 										<logHandler>
 											<outputToConsole>true</outputToConsole>
@@ -1264,9 +1265,9 @@
 										<outputDirectory>
 											${generated-docs-singlepage-output.dir}
 										</outputDirectory>
-										<sourceHighlighter>highlight.js</sourceHighlighter>
 										<doctype>book</doctype>
 										<attributes>
+											<source-highlighter>highlight.js</source-highlighter>
 											<docinfo>shared</docinfo>
 											<stylesdir>css/</stylesdir>
 											<stylesheet>spring.css</stylesheet>


### PR DESCRIPTION
Resolves GH-232

Syntax highlighting was not being added to code snippets in documentation for projects that inherit from this project.

With this fix it works properly:

<img width="1025" alt="Syntax Highlighting" src="https://user-images.githubusercontent.com/76525045/185804451-2769f81c-40d4-4854-94a5-86378ccdec43.png">

Maybe it's worth testing a few highlighting styles to see which one looks better. [Spring Kafka documentation](https://docs.spring.io/spring-kafka/reference/html/) for example uses `googlecode`, which I think is easier to read:

<img width="938" alt="Spring Kafka Highlighting" src="https://user-images.githubusercontent.com/76525045/185804653-fb76a9e1-1176-4fec-9f9d-5ed9628b2641.png">

Configuration in `Spring Kafka`:

<img width="462" alt="Spring Kafka Configuration" src="https://user-images.githubusercontent.com/76525045/185804663-5cc91984-2f54-4485-9a0c-e4d330d1ddc3.png">

If that looks interesting I can take a look into changing it for this project.

Hope this helps, and please let me know if it looks ok or if there's anything to change.

Thanks!