### PR TITLE
fix: update README.adoc error link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -213,13 +213,13 @@ The following files can be found in the https://github.com/spring-cloud/spring-c
 
 .Code style
 
-image::intellij-code-style.png[Code style]
+image::docs/modules/ROOT/assets/images/intellij-code-style.png[Code style]
 
 Go to `File` -> `Settings` -> `Editor` -> `Code style`. There click on the icon next to the `Scheme` section. There, click on the `Import Scheme` value and pick the `Intellij IDEA code style XML` option. Import the `spring-cloud-build-tools/src/main/resources/intellij/Intellij_Spring_Boot_Java_Conventions.xml` file.
 
 .Inspection profiles
 
-image::intellij-inspections.png[Code style]
+image::docs/modules/ROOT/assets/images/intellij-inspections.png[Code style]
 
 Go to `File` -> `Settings` -> `Editor` -> `Inspections`. There click on the icon next to the `Profile` section. There, click on the `Import Profile` and import the `spring-cloud-build-tools/src/main/resources/intellij/Intellij_Project_Defaults.xml` file.
 
@@ -227,7 +227,7 @@ Go to `File` -> `Settings` -> `Editor` -> `Inspections`. There click on the icon
 
 To have Intellij work with Checkstyle, you have to install the `Checkstyle` plugin. It's advisable to also install the `Assertions2Assertj` to automatically convert the JUnit assertions
 
-image::intellij-checkstyle.png[Checkstyle]
+image::docs/modules/ROOT/assets/images/intellij-checkstyle.png[Checkstyle]
 
 Go to `File` -> `Settings` -> `Other settings` -> `Checkstyle`. There click on the `+` icon in the `Configuration file` section. There, you'll have to define where the checkstyle rules should be picked from. In the image above, we've picked the rules from the cloned Spring Cloud Build repository. However, you can point to the Spring Cloud Build's GitHub repository (e.g. for the `checkstyle.xml` : `https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/main/spring-cloud-build-tools/src/main/resources/checkstyle.xml`). We need to provide the following variables:
 


### PR DESCRIPTION
I propose that the image link in the README.adoc of the open source project under spring-cloud be changed to 

`https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/main/docs/modules/ROOT/assets/images` or 
`https://github.com/spring-cloud/spring-cloud-build/blob/main/docs/modules/ROOT/assets/images`

If possible, this task can be assigned to me. I'm more than willing to contribute.