### PR TITLE
Changes to use parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,13 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-build-docs-build</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-build</artifactId>
+		<version>4.1.3-SNAPSHOT</version>
+	</parent>
 
 	<name>Spring Cloud Build Docs Build</name>
 	<description>Builds Spring Cloud Build Docs.</description>
@@ -22,47 +26,13 @@
 		<url>https://github.com/spring-cloud/spring-cloud-build/issues</url>
 	</issueManagement>
 
-	<properties>
-		<maven.antora-version>1.0.0-alpha.4</maven.antora-version>
-		<!-- Our Jenkins Servers are running Ubuntu 18.04 which uses glibc 2.27.  This version of glibc is only compatible with Node 16.x -->
-		<node.version>v16.20.2</node.version>
-	</properties>
-
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.antora</groupId>
 				<artifactId>antora-maven-plugin</artifactId>
-				<version>${maven.antora-version}</version>
-				<extensions>true</extensions>
-				<configuration>
-					<nodeVersion>${node.version}</nodeVersion>
-					<options>
-						<option>--to-dir=target/antora/site</option>
-						<option>--stacktrace</option>
-						<option>--fetch</option>
-					</options>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<repository>
-			<id>spring-snapshot</id>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>spring-milestone</id>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
-	</repositories>
 
 </project>


### PR DESCRIPTION
I have consolidatated some of what is used in this POM to our `spring-cloud-build` POM which we needed there anyways.  

See https://github.com/spring-cloud/spring-cloud-build/blob/24ad0c7042234b7668a66b531940a0adfd1fd60a/pom.xml#L1070-L1092

If we change the `docs-build` pom to use `spring-cloud-build` as a parent we can eliminate a lot of overhead of maintaining the POM in two different branches for each project.

The only change would be we would need to activate the `docs` profile when running `./mvnw antora` (which we currently do not have to do).

