### PR TITLE
Ignore release-train workflow files in Dependabot actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
     schedule:
       interval: "weekly"
   - package-ecosystem: maven


### PR DESCRIPTION
Dependabot GitHub Actions updates should not touch the release-train workflow files, which are managed outside normal dependency bump flow and can create noisy or undesired update PRs.

This change adds `exclude-paths` to the `github-actions` update block in `.github/dependabot.yml` so Dependabot skips:
- `.github/workflows/release-train-test.yml`
- `.github/workflows/release-train-build.yml`

No other Dependabot ecosystems or schedules were changed.