### PR TITLE
Pin maven-deploy-plugin version in spring-cloud-dependencies-parent

### DIFF
--- a/spring-cloud-dependencies-parent/pom.xml
+++ b/spring-cloud-dependencies-parent/pom.xml
@@ -71,6 +71,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+		<maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
 	</properties>
 	<distributionManagement>
 		<downloadUrl>https://github.com/spring-cloud</downloadUrl>
@@ -208,6 +209,11 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>${maven-deploy-plugin.version}</version>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
`spring-cloud-dependencies-parent` has no parent POM and does not manage the `maven-deploy-plugin`, so with Maven < 3.9 it falls back to the core default `maven-deploy-plugin` **2.7**. (Maven 3.9.0 was the release that bumped the default lifecycle binding to 3.1.x.)

Version 2.7 predates the `altSnapshotDeploymentRepository` parameter (added in 2.8), so any deploy that relies on that flag is silently ignored for this module, and it falls back to the repository declared in its own `distributionManagement`.

This pins `maven-deploy-plugin` to **3.1.4** — the same version already used by the `spring-cloud-build` root POM — so the module honors the alternate deployment repository flags.
